### PR TITLE
Specify the list of required fields for mkjson

### DIFF
--- a/bin/mkjson.py
+++ b/bin/mkjson.py
@@ -5,7 +5,7 @@ import sys
 import json
 import re
 
-@Configuration()
+@Configuration(required_fields=["*"])
 class MkJSONCommand(StreamingCommand):
     """ 
 


### PR DESCRIPTION
Specified the list of required fields so that Splunk doesn't optimize out any of the fields required by `mkjson`.

Repro:
```
index=_introspection
 | head 10
 | mkjson component, log_level
 | fields _time,_raw
 ```